### PR TITLE
Add support for non-`LEAN_USE_GMP` builds

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -4,13 +4,21 @@ import Qq
 open IO System Process Lean Qq
 
 def main (args : List String) : IO Unit := do
-  match args with
+  let mut new_args := []
+  let mut context : OLeanParser.Context := { useGMP := true }
+  for a in args.reverse do
+    if a = "--no-gmp" then
+      context := { context with useGMP := false }
+    else
+      new_args := a :: new_args
+
+  match new_args with
   | [] =>
     println "Usage: ... filename [mod ...]"
     exit 1
   | file :: mods =>
     let cnt ← IO.FS.readBinFile file
-    let ({ githash, base, objs, root }, _last) ← IO.ofExcept <| parseOLean.run cnt
+    let ({ githash, base, objs, root }, _last) ← IO.ofExcept <| (parseOLean.run context).run cnt
     IO.println s!"githash = {githash}"
     initSearchPath (← findSysroot)
     let opts := ({} : Options)

--- a/OLeanDump.lean
+++ b/OLeanDump.lean
@@ -3,19 +3,25 @@ import OLeanDump.ByteArrayParser
 open IO
 open ByteArrayParser
 
+structure OLeanParser.Context where
+  /-- Whether the olean was produced using a Lean built with `LEAN_USE_GMP`. -/
+  useGMP : Bool
+
+abbrev OLeanParser := ReaderT OLeanParser.Context ByteArrayParser
+
 def ObjPtr.parse (ptr : UInt64) : ObjPtr :=
   if ptr &&& 1 = 1 then
     ObjPtr.scalar <| ptr.toNat >>> 1
   else
     ObjPtr.ptr ptr
 
-def parseArrayElems (n : Nat) : ByteArrayParser (Array ObjPtr) := do
+def parseArrayElems (n : Nat) : OLeanParser (Array ObjPtr) := do
   let mut arr := #[]
   for _i in [0:n] do
     arr := arr.push (.parse (← read64LE))
   pure <| arr
 
-def parseObj : ByteArrayParser Obj := do
+def parseObj : OLeanParser Obj := do
   let rc ← read32LE
   unless rc = 0 do panic! s!"nonpersistent object: rc={rc}"
   let cs_sz ← read16LE
@@ -48,21 +54,33 @@ def parseObj : ByteArrayParser Obj := do
     let utf8 := utf8.extract 0 (utf8.size - 1) -- drop zero terminator
     pure <| Obj.string <| String.fromUTF8! utf8 -- TODO
   | 250 =>
-    let capacity ← read32LE
-    let signSize ← read32LE
-    let (size, sign) := -- TODO: implement Int32
-      if (signSize >>> 31) == 0 then
-        (signSize, 1)
-      else
-        (0-signSize, -1)
-    unless size = capacity do
-      panic! s!"mpz has different capacity={capacity} than size={size}"
-    let _limbsPtr ← read64LE
-    -- TODO: verify that limbsPtr starts here
-    let limbs ← readArray size.toNat read64LE -- mb_limb_t
-    let nat : Nat := limbs.foldr (init := 0) -- limbs are little-endian
-      fun limb acc => (acc <<< 64) ||| limb.toNat
-    pure <| Obj.mpz (sign * nat)
+    if (← read).useGMP then
+      let capacity ← read32LE
+      let signSize ← read32LE
+      let (size, sign) := -- TODO: implement Int32
+        if (signSize >>> 31) == 0 then
+          (signSize, 1)
+        else
+          (0-signSize, -1)
+      unless size = capacity do
+        panic! s!"mpz has different capacity={capacity} than size={size}"
+      let _limbsPtr ← read64LE
+      -- TODO: verify that limbsPtr starts here
+      let limbs ← readArray size.toNat read64LE -- mb_limb_t
+      let nat : Nat := limbs.foldr (init := 0) -- limbs are little-endian
+        fun limb acc => (acc <<< 64) ||| limb.toNat
+      pure <| Obj.mpz (sign * nat)
+    else
+      let sign := if (← read8) ≠ 0 then -1 else 1
+      -- TODO(https://github.com/leanprover/lean4/pull/2908): as well as not always being zero, the
+      -- length of this padding is platform-dependent.
+      let padding ← readBytes 7
+      let size ← read64LE
+      let _limbsPtr ← read64LE
+      let limbs ← readArray size.toNat read32LE
+      let nat : Nat := limbs.foldr (init := 0) -- limbs are little-endian
+        fun limb acc => (acc <<< 32) ||| limb.toNat
+      pure <| Obj.mpz (sign * nat) (some padding)
   | 251 =>
     let value ← read64LE
     let closure ← read64LE
@@ -99,7 +117,7 @@ structure OLeanFile where
   objs : ObjLookup
   root : ObjPtr
 
-def parseOLean : ByteArrayParser OLeanFile := do
+def parseOLean : OLeanParser OLeanFile := do
   let pos0 ← get
   expectBs "olean".toUTF8
   expectB 1 -- v1 olean

--- a/OLeanDump.lean
+++ b/OLeanDump.lean
@@ -72,8 +72,7 @@ def parseObj : OLeanParser Obj := do
       pure <| Obj.mpz (sign * nat)
     else
       let sign := if (← read8) ≠ 0 then -1 else 1
-      -- TODO(https://github.com/leanprover/lean4/pull/2908): as well as not always being zero, the
-      -- length of this padding is platform-dependent.
+      -- This padding is not always zero (https://github.com/leanprover/lean4/pull/2908)
       let padding ← readBytes 7
       let size ← read64LE
       let _limbsPtr ← read64LE


### PR DESCRIPTION
This adds a `--no-gmp` flag which can parse oleans from such a lean binary. These oleans contain embedded padding bytes; this chooses to explicictly include them in the output, to aid with debugging otherwise-identical oleans.